### PR TITLE
Handle empty JSON bodies to avoid 500 errors in Chrome

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,8 +6,19 @@ const bodyParser = require("body-parser");
 const app = express();
 const port = 3001;
 
-app.use(bodyParser.json());
+// parse JSON bodies, but tolerate empty payloads so GET requests with
+// a `Content-Type: application/json` header do not trigger a crash that
+// manifests as "Unexpected end of input" in some browsers (e.g. Chrome)
+app.use(bodyParser.json({ strict: false }));
 app.use(bodyParser.urlencoded({ extended: true }));
+
+// gracefully handle malformed JSON payloads
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && "body" in err) {
+    return res.status(400).json({ message: "Invalid JSON payload" });
+  }
+  next();
+});
 
 // compresses all the responses
 app.use(compression());


### PR DESCRIPTION
## Summary
- Allow body-parser to accept empty JSON payloads and avoid crashes when Chrome sends `Content-Type: application/json`
- Return a clear 400 response for malformed JSON bodies

## Testing
- `node --check backend/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689eb4dc11f883288f88421a5dd4115b