### PR TITLE
feat: add kiosk-style landing page

### DIFF
--- a/frontend_vite/src/App.css
+++ b/frontend_vite/src/App.css
@@ -1,42 +1,92 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.timestamp-bar {
+  background-color: #eceff1;
+  color: #000;
+  padding: 0.25rem;
+  font-size: 0.9rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.header {
+  display: flex;
+  align-items: center;
+  background-color: #00695c;
+  padding: 0.5rem;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.hospital-logo {
+  height: 60px;
+  margin-right: 0.5rem;
 }
 
-.card {
-  padding: 2em;
+.hospital-info {
+  text-align: left;
+  color: #fff;
 }
 
-.read-the-docs {
-  color: #888;
+.hospital-name {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.hospital-address {
+  font-size: 0.9rem;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 1rem;
+}
+
+.instruction {
+  margin: 1rem 0;
+  font-size: 1.1rem;
+}
+
+.card-image img {
+  height: 140px;
+}
+
+.buttons {
+  width: 100%;
+  max-width: 320px;
+  margin-top: 1rem;
+}
+
+.btn {
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #000;
+}
+
+.btn.primary {
+  background-color: #ffca28;
+}
+
+.btn.danger {
+  background-color: #e53935;
+  color: #fff;
+}
+
+.btn.secondary {
+  background-color: #26a69a;
+  color: #fff;
+}
+
+.btn.muted {
+  background-color: #bdbdbd;
 }

--- a/frontend_vite/src/App.jsx
+++ b/frontend_vite/src/App.jsx
@@ -1,35 +1,51 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useState } from 'react'
+import cardImage from './assets/react.svg'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
+export default function App() {
+  const [now, setNow] = useState(new Date())
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(timer)
+  }, [])
+
+  const weekday = now.toLocaleDateString('th-TH', { weekday: 'long' })
+  const dateStr = now.toLocaleDateString('th-TH', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+  const timeStr = now.toLocaleTimeString('th-TH')
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="container">
+      <div className="timestamp-bar">
+        {`${weekday} ที่ ${dateStr} เวลา ${timeStr} น.`}
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
+      <header className="header">
+        <img src="/vite.svg" alt="โลโก้" className="hospital-logo" />
+        <div className="hospital-info">
+          <div className="hospital-name">รพ.สต.นาฟิน</div>
+          <div className="hospital-address">
+            หมู่ 02 ตำบลนาฟิน อำเภอศรีเมืองใหม่ จังหวัดอุบลราชธานี
+          </div>
+        </div>
+      </header>
+      <main className="main">
+        <p className="instruction">
+          กรุณาเสียบบัตรประชาชนก่อนยืนยันตัวตน
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+        <div className="card-image">
+          <img src={cardImage} alt="ตัวอย่างบัตรประชาชน" />
+        </div>
+        <div className="buttons">
+          <button className="btn primary">ยืนยันตัวตน</button>
+          <button className="btn danger">ยกเลิกการโดยไม่ยืนยันตัวตน</button>
+          <button className="btn secondary">พิมพ์บัตรคิว</button>
+          <button className="btn muted">ปิดสิทธิ(ยืนยันตัวตน)</button>
+        </div>
+      </main>
+    </div>
   )
 }
-
-export default App

--- a/frontend_vite/src/index.css
+++ b/frontend_vite/src/index.css
@@ -1,68 +1,10 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  font-family: system-ui, sans-serif;
+  background-color: #009688;
+  color: #fff;
+}
+
+#root {
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- add timestamp header and hospital info to first screen
- show ID card instructions and action buttons styled like kiosk UI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ec11737b883289979184427f8b86c