### PR TITLE
Display Thai ID card after identity confirmation

### DIFF
--- a/frontend_vite/src/App.css
+++ b/frontend_vite/src/App.css
@@ -91,21 +91,70 @@
   background-color: #bdbdbd;
 }
 
-.card-info {
+.id-card {
   margin-top: 1rem;
   background-color: #e0f7fa;
-  padding: 1rem;
   border-radius: 8px;
-  text-align: left;
+  border: 1px solid #999;
+  padding: 0.5rem 1rem;
   width: 100%;
-  max-width: 360px;
+  max-width: 460px;
+  text-align: left;
 }
 
-.card-info .row {
+.id-card-header {
+  text-align: center;
+  font-weight: 700;
   margin-bottom: 0.5rem;
 }
 
-.card-info .label {
+.id-card-body {
+  display: flex;
+}
+
+.id-card-chip {
+  width: 60px;
+  height: 40px;
+  background: #ffeb3b;
+  border: 1px solid #999;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+  flex-shrink: 0;
+}
+
+.id-card-details {
+  flex: 1;
+}
+
+.id-card-details .row {
+  margin-bottom: 0.25rem;
+}
+
+.id-card-details .label {
+  display: block;
+  font-weight: 700;
+}
+
+.id-card-photo {
+  width: 120px;
+  height: 140px;
+  object-fit: cover;
+  margin-left: 0.5rem;
+  border-radius: 4px;
+}
+
+.id-card-footer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.id-card-footer .column {
+  flex: 1;
+}
+
+.id-card-footer .label {
   display: block;
   font-weight: 700;
 }

--- a/frontend_vite/src/App.jsx
+++ b/frontend_vite/src/App.jsx
@@ -1,56 +1,9 @@
 import { useEffect, useState } from 'react'
 import cardImage from './assets/react.svg'
+import ThaiIDCard from './components/ThaiIDCard'
 import './App.css'
 
 export default function App() {
-  const getField = (obj, keys) => {
-    for (const key of keys) {
-      if (obj && obj[key]) return obj[key]
-    }
-    return ''
-  }
-
-  const formatCid = (cid) => {
-    if (!cid) return ''
-    const digits = cid.toString().replace(/\D/g, '')
-    if (digits.length !== 13) return cid
-    return digits.replace(/(\d{1})(\d{4})(\d{5})(\d{2})(\d{1})/, '$1 $2 $3 $4 $5')
-  }
-
-  const formatDob = (dob) => {
-    if (!dob) return ''
-    const str = dob.toString()
-    if (str.length !== 8) return dob
-    let year = parseInt(str.slice(0, 4), 10)
-    const month = parseInt(str.slice(4, 6), 10) - 1
-    const day = parseInt(str.slice(6, 8), 10)
-    if (year > 2400) year -= 543
-    const date = new Date(year, month, day)
-    return date.toLocaleDateString('th-TH', {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-    })
-  }
-
-  const formatAddress = (info) => {
-    if (!info) return ''
-    if (info.address)
-      return info.address.replace(/undefined/g, '').replace(/\s+/g, ' ').trim()
-    const houseNo = getField(info, ['houseNo', 'hno'])
-    const villageNo = getField(info, ['moo', 'villageNo'])
-    const subDistrict = getField(info, ['tambon', 'subdistrict'])
-    const district = getField(info, ['amphur', 'district'])
-    const province = getField(info, ['province'])
-    const parts = []
-    if (houseNo) parts.push(houseNo)
-    if (villageNo) parts.push(`หมู่ที่ ${villageNo}`)
-    if (subDistrict) parts.push(`ตำบล${subDistrict}`)
-    if (district) parts.push(`อำเภอ${district}`)
-    if (province) parts.push(`จังหวัด${province}`)
-    return parts.join(' ')
-  }
-
   const [now, setNow] = useState(new Date())
   const [hospital, setHospital] = useState(null)
   const [dbError, setDbError] = useState(false)
@@ -131,30 +84,7 @@ export default function App() {
           <button className="btn secondary">พิมพ์บัตรคิว</button>
           <button className="btn muted">ปิดสิทธิ(ยืนยันตัวตน)</button>
         </div>
-        {cardInfo && (
-          <div className="card-info">
-            <div className="row">
-              <span className="label">Identification Number</span>
-              <span>{formatCid(getField(cardInfo, ['cid', 'pid', 'nationalId']))}</span>
-            </div>
-            <div className="row">
-              <span className="label">Name</span>
-              <span>{getField(cardInfo, ['firstname', 'fname', 'firstNameTH', 'name'])}</span>
-            </div>
-            <div className="row">
-              <span className="label">Last name</span>
-              <span>{getField(cardInfo, ['lastname', 'lname', 'lastNameTH', 'surname'])}</span>
-            </div>
-            <div className="row">
-              <span className="label">Date of Birth</span>
-              <span>{formatDob(getField(cardInfo, ['birthdate', 'birthDate', 'dob']))}</span>
-            </div>
-            <div className="row">
-              <span className="label">Address</span>
-              <span>{formatAddress(cardInfo)}</span>
-            </div>
-          </div>
-        )}
+        {cardInfo && <ThaiIDCard info={cardInfo} />}
       </main>
     </div>
   )

--- a/frontend_vite/src/components/ThaiIDCard.jsx
+++ b/frontend_vite/src/components/ThaiIDCard.jsx
@@ -1,0 +1,103 @@
+import React from 'react'
+
+export default function ThaiIDCard({ info }) {
+  const getField = (obj, keys) => {
+    for (const key of keys) {
+      if (obj && obj[key]) return obj[key]
+    }
+    return ''
+  }
+
+  const formatCid = (cid) => {
+    if (!cid) return ''
+    const digits = cid.toString().replace(/\D/g, '')
+    if (digits.length !== 13) return cid
+    return digits.replace(/(\d{1})(\d{4})(\d{5})(\d{2})(\d{1})/, '$1 $2 $3 $4 $5')
+  }
+
+  const formatDob = (dob) => {
+    if (!dob) return ''
+    const str = dob.toString()
+    if (str.length !== 8) return dob
+    let year = parseInt(str.slice(0, 4), 10)
+    const month = parseInt(str.slice(4, 6), 10) - 1
+    const day = parseInt(str.slice(6, 8), 10)
+    if (year > 2400) year -= 543
+    const date = new Date(year, month, day)
+    return date.toLocaleDateString('th-TH', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  const formatAddress = (info) => {
+    if (!info) return ''
+    if (info.address) {
+      return info.address.replace(/undefined/g, '').replace(/\s+/g, ' ').trim()
+    }
+    const houseNo = getField(info, ['houseNo', 'hno'])
+    const villageNo = getField(info, ['moo', 'villageNo'])
+    const subDistrict = getField(info, ['tambon', 'subdistrict'])
+    const district = getField(info, ['amphur', 'district'])
+    const province = getField(info, ['province'])
+    const parts = []
+    if (houseNo) parts.push(houseNo)
+    if (villageNo) parts.push(`หมู่ที่ ${villageNo}`)
+    if (subDistrict) parts.push(`ตำบล${subDistrict}`)
+    if (district) parts.push(`อำเภอ${district}`)
+    if (province) parts.push(`จังหวัด${province}`)
+    return parts.join(' ')
+  }
+
+  const formatDate = (date) => {
+    if (!date) return ''
+    return formatDob(date)
+  }
+
+  const photo = getField(info, ['photo'])
+  const photoSrc = photo ? `data:image/jpeg;base64,${photo}` : ''
+
+  return (
+    <div className="id-card">
+      <div className="id-card-header">Thai National ID Card</div>
+      <div className="id-card-body">
+        <div className="id-card-chip" />
+        <div className="id-card-details">
+          <div className="row">
+            <span className="label">Identification Number</span>
+            <span>{formatCid(getField(info, ['cid', 'pid', 'nationalId']))}</span>
+          </div>
+          <div className="row">
+            <span className="label">Name</span>
+            <span>{getField(info, ['firstname', 'fname', 'firstNameTH', 'name'])}</span>
+          </div>
+          <div className="row">
+            <span className="label">Last Name</span>
+            <span>{getField(info, ['lastname', 'lname', 'lastNameTH', 'surname'])}</span>
+          </div>
+          <div className="row">
+            <span className="label">Date of Birth</span>
+            <span>{formatDob(getField(info, ['birthdate', 'birthDate', 'dob']))}</span>
+          </div>
+          <div className="row">
+            <span className="label">Address</span>
+            <span className="address">{formatAddress(info)}</span>
+          </div>
+        </div>
+        {photoSrc && <img className="id-card-photo" src={photoSrc} alt="card" />}
+      </div>
+      <div className="id-card-footer">
+        <div className="column">
+          <span className="label">Date of Issue</span>
+          <span>{formatDate(getField(info, ['issueDate']))}</span>
+        </div>
+        <div className="column">
+          <span className="label">Date of Expiry</span>
+          <span>{formatDate(getField(info, ['expireDate', 'expiryDate']))}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Fetch ID card data from backend on confirmation
- Render detailed Thai ID card with photo and metadata
- Add styling for card layout and chip appearance

## Testing
- `npm test` (frontend, fails: Missing script)
- `npm run lint`
- `npm test` (backend, fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689ecc53f72c8328805e53338b5d6958