### PR TITLE
Show alert when ID card is missing

### DIFF
--- a/frontend_vite/src/App.jsx
+++ b/frontend_vite/src/App.jsx
@@ -46,7 +46,7 @@ export default function App() {
           setCardInfo(result.data)
         } else {
           setCardInfo(null)
-          alert('ไม่สามารถอ่านข้อมูลบัตรได้')
+          alert(result.message || 'ไม่สามารถอ่านข้อมูลบัตรได้')
         }
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- Display backend error message on confirm if no card or read failure occurs

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ecf121190832899519e07347283e1