### PR TITLE
feat(frontend): refine home screen buttons

### DIFF
--- a/frontend_vite/src/App.css
+++ b/frontend_vite/src/App.css
@@ -71,6 +71,10 @@
   border-radius: 8px;
   cursor: pointer;
   color: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .btn.primary {
@@ -89,6 +93,11 @@
 
 .btn.muted {
   background-color: #bdbdbd;
+}
+
+.btn .icon {
+  width: 24px;
+  height: 24px;
 }
 
 .id-card {

--- a/frontend_vite/src/App.jsx
+++ b/frontend_vite/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import cardImage from './assets/react.svg'
+import printerIcon from './assets/printer.svg'
 import ThaiIDCard from './components/ThaiIDCard'
 import './App.css'
 
@@ -80,9 +81,13 @@ export default function App() {
           <button className="btn primary" onClick={handleConfirm}>
             ยืนยันตัวตน
           </button>
-          <button className="btn danger">ยกเลิกการโดยไม่ยืนยันตัวตน</button>
-          <button className="btn secondary">พิมพ์บัตรคิว</button>
-          <button className="btn muted">ปิดสิทธิ(ยืนยันตัวตน)</button>
+          <button className="btn danger">เปิดบริการโดยไม่ยืนยันตัวตน</button>
+          <button className="btn secondary">เช็คสิทธิรักษาพยาบาล</button>
+          <button className="btn muted">
+            <img src={printerIcon} alt="ไอคอนพิมพ์" className="icon" />
+            พิมพ์บัตรคิว
+          </button>
+          <button className="btn danger">ปิดสิทธิ(ยืนยันตัวตน)</button>
         </div>
         {cardInfo && <ThaiIDCard info={cardInfo} />}
       </main>

--- a/frontend_vite/src/assets/printer.svg
+++ b/frontend_vite/src/assets/printer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="6 9 6 4 18 4 18 9" />
+  <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+  <rect x="6" y="14" width="12" height="8" rx="2" />
+</svg>


### PR DESCRIPTION
## Summary
- update home screen to match latest button layout
- add health rights check and printer icon
- tweak button styles for centered icon support

## Testing
- `cd frontend_vite && npm run lint`
- `cd frontend_vite && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ed0f34ca483288071aaa416284079