### PR TITLE
Use default Thai ID card background image

### DIFF
--- a/frontend_vite/src/components/ThaiIDCard.jsx
+++ b/frontend_vite/src/components/ThaiIDCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import './ThaiIDCard.css'
+import thaiIdBg from '../assets/thai-id-bg.png'
 
 export default function ThaiIDCard({ info }) {
   const getField = (obj, keys) => {
@@ -59,7 +60,9 @@ export default function ThaiIDCard({ info }) {
   const photo = getField(info, ['photo'])
   const photoSrc = photo ? `data:image/jpeg;base64,${photo}` : ''
   const bg = getField(info, ['cardBg', 'bg', 'background'])
-  const bgStyle = bg ? { backgroundImage: `url(data:image/png;base64,${bg})` } : {}
+  const bgStyle = bg
+    ? { backgroundImage: `url(data:image/png;base64,${bg})` }
+    : { backgroundImage: `url(${thaiIdBg})` }
 
   return (
     <div className="thai-id-card" style={bgStyle}>


### PR DESCRIPTION
## Summary
- default to built-in Thai ID background when no base64 image provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ee44617dc832883dfbd2fc6bb8cab