### PR TITLE
Add backend-linked health rights check in kiosk UI

### DIFF
--- a/frontend_vite/src/App.css
+++ b/frontend_vite/src/App.css
@@ -100,6 +100,20 @@
   height: 24px;
 }
 
+.rights-info {
+  margin-top: 1rem;
+  text-align: left;
+  background-color: #e0f2f1;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 360px;
+}
+
+.rights-info div {
+  margin-bottom: 0.25rem;
+}
+
 .id-card {
   margin-top: 1rem;
   background-color: #e0f7fa;


### PR DESCRIPTION
## Summary
- implement medical rights check button using backend data
- show ID, name, age, main/secondary rights
- style rights display panel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ef523d9408328890fa727e9d3094b