### PR TITLE
feat: add confirm modal for cid search

### DIFF
--- a/frontend_vite/src/App.css
+++ b/frontend_vite/src/App.css
@@ -168,6 +168,17 @@
   margin-top: 1rem;
 }
 
+.modal-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.modal-actions .btn {
+  flex: 1;
+}
+
 .id-card {
   margin-top: 1rem;
   background-color: #e0f7fa;

--- a/frontend_vite/src/App.jsx
+++ b/frontend_vite/src/App.jsx
@@ -164,6 +164,28 @@ export default function App() {
     setIsCidModalOpen(false)
   }
 
+  const handleConfirmPerson = () => {
+    if (!personInfo) return
+    fetch('http://localhost:3001/jhcis/api/v1/visit/newvisit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pcucode: personInfo.pcucodeperson,
+        pid: personInfo.pid,
+        rightcode: personInfo.rightcode,
+        rightno: personInfo.rightno,
+        hosmain: personInfo.hosmain,
+        hossub: personInfo.hossub,
+      }),
+    })
+      .then(() => {
+        setPersonInfo(null)
+        setCidInput('')
+      })
+      .catch(() => {})
+      .finally(() => setIsPersonModalOpen(false))
+  }
+
   const closeCidModal = () => {
     setIsCidModalOpen(false)
   }
@@ -268,16 +290,26 @@ export default function App() {
         <div className="modal">
           <div className="modal-content">
             {personInfo ? (
-              <div className="rights-info">
-                <div>หมายเลขบัตรประชาชน: {personInfo.idcard}</div>
-                <div>ชื่อ: {`${personInfo.titlename || ''}${personInfo.fname || ''} ${personInfo.lname || ''}`}</div>
-              </div>
+              <>
+                <div className="rights-info">
+                  <div>
+                    HN:{personInfo.pid} {`${personInfo.titlename || ''}${personInfo.fname || ''} ${personInfo.lname || ''}`}
+                  </div>
+                  <div>ยืนยันการเปิดบริการ</div>
+                </div>
+                <div className="modal-actions">
+                  <button className="btn primary" onClick={handleConfirmPerson}>ยืนยัน</button>
+                  <button className="btn danger" onClick={closePersonModal}>ยกเลิก</button>
+                </div>
+              </>
             ) : (
-              <div className="rights-info">ไม่พบข้อมูล โปรดติดต่อ จนท.</div>
+              <>
+                <div className="rights-info">ไม่พบข้อมูล โปรดติดต่อ จนท.</div>
+                <button className="btn secondary modal-close" onClick={closePersonModal}>
+                  ปิด
+                </button>
+              </>
             )}
-            <button className="btn secondary modal-close" onClick={closePersonModal}>
-              ปิด
-            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add modal to confirm opening service when CID search finds person
- send visit creation request to backend upon confirmation
- style modal actions for confirm/cancel buttons

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f11db438c8328ac994e4e88f41f6c