### PR TITLE
feat: verify person and auto create outside-area record

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -54,6 +54,7 @@ const closeRight = async (req, res) => {
 #### 3.3 Person APIs
 - `GET /api/person/:cid` - ดึงข้อมูลบุคคล
 - `POST /api/person` - เพิ่มข้อมูลบุคคลใหม่
+- `POST /api/person/verify` - ตรวจสอบและเพิ่มบุคคลใหม่ (หมู่นอกเขต)
 - `PATCH /api/person/:pid` - อัพเดทข้อมูลบุคคล
 
 ### 4. Dependencies หลัก

--- a/backend/src/controller/person.controller.js
+++ b/backend/src/controller/person.controller.js
@@ -116,6 +116,52 @@ exports.postNewPerson = (req, res) => {
 };
 
 
+exports.verifyPerson = (req, res) => {
+  if (
+    !req.body ||
+    !req.body.idcard ||
+    !req.body.prename ||
+    !req.body.fname ||
+    !req.body.lname ||
+    !req.body.birth ||
+    !req.body.sex
+  ) {
+    res.status(400).send({
+      ok: false,
+      message:
+        "idcard, prename, fname, lname, birth and sex are required!",
+      error: null,
+    });
+    return;
+  }
+
+  person.findOrCreateByCid(req.body, (err, data) => {
+    if (err) {
+      if (err.message === "house_not_found") {
+        res.status(400).send({
+          ok: false,
+          message: "House out area not found!",
+          error: null,
+        });
+      } else {
+        logger.error(err.toString());
+        res.status(500).send({
+          ok: false,
+          message: "",
+          error: err.toString(),
+        });
+      }
+    } else {
+      res.status(200).send({
+        ok: true,
+        message: "",
+        data,
+      });
+    }
+  });
+};
+
+
 exports.updateMobilePhone = (req, res) => {
   if (!req.params.pid) {
     res.status(400).send({

--- a/backend/src/routes/index.routes.js
+++ b/backend/src/routes/index.routes.js
@@ -16,6 +16,7 @@ module.exports = (app) => {
   router.get("/person/:cid", person.getPersonByCid);
   router.get("/persons/maxpid", person.getMaxPersonPid);
   router.post("/person", person.postNewPerson);
+  router.post("/person/verify", person.verifyPerson);
   router.get("/village/outarea", village.getVillageOutArea);
   router.get("/house/:villcode", house.findByVillcode);
   router.get("/house", house.houseOutArea);


### PR DESCRIPTION
## Summary
- add model logic to find or create person in outside-area house
- expose verifyPerson controller and route
- document new API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad75d2fb488328b4f84d8eb81d9215